### PR TITLE
Allow running callbacks when an item's highlight status changes

### DIFF
--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -1,9 +1,8 @@
-import 'package:bot_toast/bot_toast.dart';
+import 'package:contextual_menu/contextual_menu.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' hide MenuItem;
 import 'package:preference_list/preference_list.dart';
-import 'package:contextual_menu/contextual_menu.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -16,6 +15,8 @@ class _HomePageState extends State<HomePage> {
   bool _shouldReact = false;
   Offset? _position;
   Placement _placement = Placement.bottomLeft;
+  String? _highlighted;
+  String? _selected;
 
   Menu? _menu;
 
@@ -24,59 +25,119 @@ class _HomePageState extends State<HomePage> {
     super.initState();
   }
 
+  void _onClick(MenuItem item) {
+    setState(() {
+      _selected = item.label;
+    });
+  }
+
+  void _onHighlight(MenuItem item) {
+    setState(() {
+      _highlighted = item.label;
+    });
+  }
+
+  void _onLoseHighlight(_) {
+    setState(() {
+      _highlighted = null;
+    });
+  }
+
   void _handleClickPopUp() {
     _menu ??= Menu(
       items: [
         MenuItem(
           label: 'Look Up "LeanFlutter"',
+          onClick: _onClick,
+          onHighlight: _onHighlight,
+          onLoseHighlight: _onLoseHighlight,
         ),
         MenuItem(
           label: 'Search with Google',
+          onClick: _onClick,
+          onHighlight: _onHighlight,
+          onLoseHighlight: _onLoseHighlight,
         ),
         MenuItem.separator(),
         MenuItem(
           label: 'Cut',
+          onClick: _onClick,
+          onHighlight: _onHighlight,
+          onLoseHighlight: _onLoseHighlight,
         ),
         MenuItem(
           label: 'Copy',
+          onClick: _onClick,
+          onHighlight: _onHighlight,
+          onLoseHighlight: _onLoseHighlight,
         ),
         MenuItem(
           label: 'Paste',
+          onClick: _onClick,
+          onHighlight: _onHighlight,
+          onLoseHighlight: _onLoseHighlight,
           disabled: true,
         ),
         MenuItem.submenu(
           label: 'Share',
+          onClick: _onClick,
+          onHighlight: _onHighlight,
+          onLoseHighlight: _onLoseHighlight,
           submenu: Menu(
             items: [
               MenuItem(
                 label: 'Item 1',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
               ),
               MenuItem(
                 label: 'Item 2',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
               ),
               MenuItem.checkbox(
                 label: 'Centered Layout',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: false,
               ),
               MenuItem.separator(),
               MenuItem.checkbox(
                 label: 'Show Primary Side Bar',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: true,
               ),
               MenuItem.checkbox(
                 label: 'Show Secondary Side Bar',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: true,
               ),
               MenuItem.checkbox(
                 label: 'Show Status Bar',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: true,
               ),
               MenuItem.checkbox(
                 label: 'Show Activity Bar',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: true,
               ),
               MenuItem.checkbox(
                 label: 'Show Panel Bar',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: false,
               ),
             ],
@@ -85,33 +146,51 @@ class _HomePageState extends State<HomePage> {
         MenuItem.separator(),
         MenuItem.submenu(
           label: 'Font',
+          onClick: _onClick,
+          onHighlight: _onHighlight,
+          onLoseHighlight: _onLoseHighlight,
           submenu: Menu(
             items: [
               MenuItem.checkbox(
                 label: 'Item 1',
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: true,
                 onClick: (menuItem) {
                   menuItem.checked = !(menuItem.checked == true);
+                  _onClick(menuItem);
                 },
               ),
               MenuItem.checkbox(
                 label: 'Item 2',
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: false,
                 onClick: (menuItem) {
                   menuItem.checked = !(menuItem.checked == true);
+                  _onClick(menuItem);
                 },
               ),
               MenuItem.separator(),
               MenuItem(
                 label: 'Item 3',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: false,
               ),
               MenuItem(
                 label: 'Item 4',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: false,
               ),
               MenuItem(
                 label: 'Item 5',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
                 checked: false,
               ),
             ],
@@ -119,13 +198,22 @@ class _HomePageState extends State<HomePage> {
         ),
         MenuItem.submenu(
           label: 'Speech',
+          onClick: _onClick,
+          onHighlight: _onHighlight,
+          onLoseHighlight: _onLoseHighlight,
           submenu: Menu(
             items: [
               MenuItem(
                 label: 'Item 1',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
               ),
               MenuItem(
                 label: 'Item 2',
+                onClick: _onClick,
+                onHighlight: _onHighlight,
+                onLoseHighlight: _onLoseHighlight,
               ),
             ],
           ),
@@ -163,6 +251,21 @@ class _HomePageState extends State<HomePage> {
                 _position = null;
                 _handleClickPopUp();
               },
+            ),
+          ],
+        ),
+        PreferenceListSection(
+          title: const Text('Results'),
+          children: [
+            PreferenceListItem(
+              disabled: true,
+              title: const Text('Highlighted'),
+              accessoryView: Text(_highlighted.toString()),
+            ),
+            PreferenceListItem(
+              disabled: true,
+              title: const Text('Selected'),
+              accessoryView: Text(_selected.toString()),
             ),
           ],
         ),

--- a/lib/src/contextual_menu.dart
+++ b/lib/src/contextual_menu.dart
@@ -16,6 +16,7 @@ class _ContextualMenu with MenuBehavior {
   final MethodChannel _channel = const MethodChannel('contextual_menu');
 
   Menu? _menu;
+  int? _lastHighlighted;
 
   Future<void> _methodCallHandler(MethodCall call) async {
     switch (call.method) {
@@ -25,6 +26,23 @@ class _ContextualMenu with MenuBehavior {
         if (menuItem != null) {
           menuItem.onClick!(menuItem);
         }
+        break;
+      case 'onMenuItemHighlight':
+        final id = call.arguments['id'] as int?;
+        if (_lastHighlighted != null && _lastHighlighted != id) {
+          final previouslyHighlighted =
+              _menu?.getMenuItemById(_lastHighlighted!);
+          previouslyHighlighted?.onLoseHighlight?.call(previouslyHighlighted);
+        }
+        _lastHighlighted = id;
+
+        if (id == null) {
+          break;
+        }
+
+        final menuItem = _menu?.getMenuItemById(id);
+        menuItem?.onHighlight?.call(menuItem);
+
         break;
     }
   }

--- a/linux/contextual_menu_plugin.cc
+++ b/linux/contextual_menu_plugin.cc
@@ -46,6 +46,24 @@ void _on_activate(GtkMenuItem* item, gpointer user_data) {
                                   result_data, nullptr, nullptr, nullptr);
 }
 
+void _on_select(GtkMenuItem* item, gpointer user_data) {
+  gint id = GPOINTER_TO_INT(user_data);
+
+  g_autoptr(FlValue) result_data = fl_value_new_map();
+  fl_value_set_string_take(result_data, "id", fl_value_new_int(id));
+  fl_method_channel_invoke_method(plugin_instance->channel,
+                                  "onMenuItemHighlight", result_data, nullptr,
+                                  nullptr, nullptr);
+}
+
+void _on_deselect(GtkMenuItem* item, gpointer user_data) {
+  g_autoptr(FlValue) result_data = fl_value_new_map();
+  fl_value_set_string_take(result_data, "id", fl_value_new_null());
+  fl_method_channel_invoke_method(plugin_instance->channel,
+                                  "onMenuItemHighlight", result_data, nullptr,
+                                  nullptr, nullptr);
+}
+
 GtkWidget* _create_menu(FlValue* args) {
   FlValue* items_value = fl_value_lookup_string(args, "items");
 
@@ -87,6 +105,10 @@ GtkWidget* _create_menu(FlValue* args) {
       }
 
       g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(_on_activate),
+                       GINT_TO_POINTER(item_id));
+      g_signal_connect(G_OBJECT(item), "select", G_CALLBACK(_on_select),
+                       GINT_TO_POINTER(item_id));
+      g_signal_connect(G_OBJECT(item), "deselect", G_CALLBACK(_on_deselect),
                        GINT_TO_POINTER(item_id));
 
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);

--- a/macos/Classes/ContextualMenu.swift
+++ b/macos/Classes/ContextualMenu.swift
@@ -9,6 +9,7 @@ import AppKit
 
 public class ContextualMenu: NSMenu, NSMenuDelegate {
     public var onMenuItemClick:((NSMenuItem) -> Void)?
+    public var onMenuItemHighlight:((NSMenuItem?) -> Void)?
     
     public override init(title: String) {
         super.init(title: title)
@@ -81,9 +82,15 @@ public class ContextualMenu: NSMenu, NSMenuDelegate {
         }
     }
     
-    // NSMenuDelegate
+    // MARK: NSMenuDelegate
     
     public func menuDidClose(_ menu: NSMenu) {
         
+    }
+
+    public func menu(_ menu: NSMenu, willHighlight item: NSMenuItem?) {
+        if (onMenuItemHighlight != nil) {
+            self.onMenuItemHighlight!(item)
+        }
     }
 }

--- a/macos/Classes/ContextualMenuPlugin.swift
+++ b/macos/Classes/ContextualMenuPlugin.swift
@@ -41,6 +41,12 @@ public class ContextualMenuPlugin: NSObject, FlutterPlugin {
             ]
             self.channel.invokeMethod("onMenuItemClick", arguments: args, result: nil)
         }
+        menu!.onMenuItemHighlight = { (menuItem: NSMenuItem?) in
+            let args: NSDictionary = [
+                "id": menuItem?.tag as Any,
+            ]
+            self.channel.invokeMethod("onMenuItemHighlight", arguments: args, result: nil)
+        }
         
         let position = args["position"]  as? [String: Any]
         let placement = args["placement"]  as! String

--- a/windows/contextual_menu_plugin.cpp
+++ b/windows/contextual_menu_plugin.cpp
@@ -148,11 +148,19 @@ std::optional<LRESULT> ContextualMenuPlugin::HandleWindowProc(HWND hWnd,
   if (message == WM_COMMAND) {
     flutter::EncodableMap eventData = flutter::EncodableMap();
     eventData[flutter::EncodableValue("id")] =
-        flutter::EncodableValue((int)wParam);
+        flutter::EncodableValue((int)LOWORD(wParam));
 
     channel->InvokeMethod("onMenuItemClick",
                           std::make_unique<flutter::EncodableValue>(eventData));
+  } else if (message == WM_MENUSELECT) {
+    flutter::EncodableMap eventData = flutter::EncodableMap();
+    eventData[flutter::EncodableValue("id")] =
+        flutter::EncodableValue((int)LOWORD(wParam));
+
+    channel->InvokeMethod("onMenuItemHighlight",
+                          std::make_unique<flutter::EncodableValue>(eventData));
   }
+
   return std::nullopt;
 }
 


### PR DESCRIPTION
This PR adds support for running callbacks in dart when menu items gain or lose highlighting. This could be useful to provide visual feedback in a Flutter application for what change a given menu item will produce.

https://user-images.githubusercontent.com/1316184/171257279-116682b2-ca5b-46a4-9651-06dd9d501c26.mp4

Caveats:
- Opening a contextual menu on macOS currently blocks the Flutter UI until the menu is closed. This is an upstream bug in flutter: flutter/flutter#104638.
- This implementation requires matching updates to [`leanflutter/menu_base`](https://github.com/leanflutter/menu_base). Since that dependency is shared with [`leanflutter/tray_manager`](https://github.com/leanflutter/tray_manager), `tray_manager` users will see the new highlight callback options but won't be able to use them unless `tray_manager` is updated to support them.