### PR TITLE
Fix open context menu blocking raster pipeline on macOS

### DIFF
--- a/macos/Classes/ContextualMenuPlugin.swift
+++ b/macos/Classes/ContextualMenuPlugin.swift
@@ -78,12 +78,36 @@ public class ContextualMenuPlugin: NSObject, FlutterPlugin {
             // skip
         }
         
-        menu?.popUp(
-            positioning: nil,
-            at: NSPoint(x: x, y: y),
-            in: mainWindow.contentView
+        let action = Action({ [self] in
+            menu?.popUp(
+                positioning: nil,
+                at: NSPoint(x: x, y: y),
+                in: mainWindow.contentView
+            )
+        })
+        RunLoop.current.perform(
+            #selector(action.action),
+            target: action,
+            argument: nil,
+            order: 0,
+            modes: [RunLoop.Mode.default]
         )
-        
+
         result(nil)
+    }
+}
+
+// Wrapper class to pass closures to Objective-C APIs that take selectors taken
+// from https://stackoverflow.com/a/36983811/1988017
+final class Action: NSObject {
+    private let _action: () -> ()
+
+    init(_ action: @escaping () -> ()) {
+        _action = action
+        super.init()
+    }
+
+    @objc func action() {
+        _action()
     }
 }


### PR DESCRIPTION
This fixes the issue where opening a context menu blocks dart animations. See: flutter/flutter#104638 for details.

To demonstrate the issue, I added a spinner to the scaffold in the example app. Here is what happens when you open the context menu using the code on `main` right now:

https://user-images.githubusercontent.com/1316184/211388907-bc50186c-f62f-483a-87b9-1d3f457ad58d.mov

And now with the changes from this PR:

https://user-images.githubusercontent.com/1316184/211389045-1f6d5af5-391c-439c-bd38-83555ae2afb4.mov

There's still a bit of visible jank when closing the menu for reasons I haven't tracked down, but it's still a significant improvement.